### PR TITLE
Update to support 1.21.3 through 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,11 @@ subprojects {
         if (JavaVersion.current() < javaVersion) {
             toolchain.languageVersion = JavaLanguageVersion.of(targetJavaVersion)
         }
-        archivesBaseName = project.archives_base_name
 
         withSourcesJar()
+    }
+
+    base {
+        archivesName = project.archives_base_name
     }
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.9.2'
+    id 'fabric-loom' version '1.15.4'
 }
 
 group 'me.lunaluna.elytra-recast'

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -1,9 +1,10 @@
 # Fabric
-    minecraft_version=1.21.4
-    yarn_mappings=1.21.4+build.8
-    loader_version=0.16.10
+    minecraft_version=1.21.3
+    supported_minecraft_versions=>=1.21.3 <=1.21.11
+    yarn_mappings=1.21.3+build.2
+    loader_version=0.16.14
 # Dependencies
-    mod_menu_version=13.0.2
-    cloth_config_version=17.0.144
+    mod_menu_version=12.0.0
+    cloth_config_version=15.0.140
 # Libraries
     gson_version=2.9.0

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -13,18 +13,12 @@
   "icon": "assets/elytra-recast/icon.png",
   "environment": "client",
   "entrypoints": {
-    "client": [
-      "me.lunaluna.fabric.elytrarecast.Startup"
-    ],
-    "modmenu": [
-      "me.lunaluna.fabric.elytrarecast.compat.modmenu.ModMenuPlugin"
-    ]
+    "client": ["me.lunaluna.fabric.elytrarecast.Startup"],
+    "modmenu": ["me.lunaluna.fabric.elytrarecast.compat.modmenu.ModMenuPlugin"]
   },
-  "mixins": [
-    "elytra-recast.mixins.json"
-  ],
+  "mixins": ["elytra-recast.mixins.json"],
   "depends": {
-    "minecraft": "~${minecraft_version}",
+    "minecraft": "${supported_minecraft_versions}",
     "fabricloader": ">=${loader_version}"
   },
   "suggests": {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This PR was entirely written by copilot (using GPT 5.4) with testing by me for my specific version (1.21.10). I updated this entirely for my own use but thought it might be useful for others. 

Hope you find it helpful. Below is a generated description of the changes in the PR.

Build tool and plugin updates:

* Upgraded the `fabric-loom` plugin version in `fabric/build.gradle` from `1.9.2` to `1.15.4` to support newer features and compatibility.
* Updated the Gradle wrapper distribution in `gradle/wrapper/gradle-wrapper.properties` from `8.11` to `9.2.0` for improved build performance and support.

Minecraft and dependency compatibility improvements:

* Changed `minecraft_version`, `yarn_mappings`, and `loader_version` in `fabric/gradle.properties` to target Minecraft `1.21.3` and support versions between `1.21.3` and `1.21.11`. Also downgraded `mod_menu_version` and `cloth_config_version` for compatibility.
* Updated `fabric.mod.json` to use the new `supported_minecraft_versions` property for specifying Minecraft dependency range, and simplified the formatting of entrypoints and mixins arrays.